### PR TITLE
Help Handler

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -6,10 +6,12 @@ import (
 )
 
 var (
-	errCommandNotFound  error = errors.New("command not found")
-	errDuplicateCommand error = errors.New("command has already been declared")
-	errOptionIsInvalid  error = errors.New("option paramaters are undefined or invalid")
-	errOptionIsSet      error = errors.New("option has already been used or shell has already been initialized")
+	errCommandNotFound    error = errors.New("command not found")
+	errDuplicateCommand   error = errors.New("command has already been declared")
+	errFlagsetParseFailed error = errors.New("flagset parse failed")
+	errHelpRequested      error = errors.New("help requested")
+	errOptionIsInvalid    error = errors.New("option paramaters are undefined or invalid")
+	errOptionIsSet        error = errors.New("option has already been used or shell has already been initialized")
 )
 
 // CommandNotFound returns a command not found error
@@ -20,6 +22,21 @@ func CommandNotFound(command string) error {
 // DuplicateCommand returns a duplicate command error
 func DuplicateCommand(command string) error {
 	return fmt.Errorf("'%s' %w", command, errDuplicateCommand)
+}
+
+// FlagsetParseFailed returns a flagset parse failed error
+func FlagsetParseFailed(reason string) error {
+	return fmt.Errorf("%w %s", errFlagsetParseFailed, reason)
+}
+
+// HelpRequested returns a help requested error
+func HelpRequested(reason string) error {
+	return fmt.Errorf("%w %s", errHelpRequested, reason)
+}
+
+// IsHelpRequested determines if the specified error is a help requested error
+func IsHelpRequested(err error) bool {
+	return errors.Is(err, errHelpRequested)
 }
 
 // OptionIsSet returns an option is set error

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -9,6 +9,7 @@ var (
 	errCommandNotFound    error = errors.New("command not found")
 	errDuplicateCommand   error = errors.New("command has already been declared")
 	errFlagsetParseFailed error = errors.New("flagset parse failed")
+	errFlagsetSetFailed   error = errors.New("flagset set failed")
 	errHelpRequested      error = errors.New("help requested")
 	errOptionIsInvalid    error = errors.New("option paramaters are undefined or invalid")
 	errOptionIsSet        error = errors.New("option has already been used or shell has already been initialized")
@@ -27,6 +28,11 @@ func DuplicateCommand(command string) error {
 // FlagsetParseFailed returns a flagset parse failed error
 func FlagsetParseFailed(reason string) error {
 	return fmt.Errorf("%w %s", errFlagsetParseFailed, reason)
+}
+
+// FlagsetSetFailed returns a flagset set failed error
+func FlagsetSetFailed(reason string) error {
+	return fmt.Errorf("%w %s", errFlagsetSetFailed, reason)
 }
 
 // HelpRequested returns a help requested error

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,6 +70,109 @@ func Test_DuplicateCommand(t *testing.T) {
 			actual := DuplicateCommand(test.input)
 			assert.Equal(t, test.expected, actual.Error())
 			assert.True(t, errors.Is(actual, errDuplicateCommand))
+		})
+	}
+}
+
+func Test_FlagsetParseFailed(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard",
+			input:    "PING",
+			expected: "flagset parse failed PING",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "flagset parse failed ",
+		},
+		{
+			name:     "lowercase",
+			input:    "ping",
+			expected: "flagset parse failed ping",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := FlagsetParseFailed(test.input)
+			assert.Equal(t, test.expected, actual.Error())
+			assert.True(t, errors.Is(actual, errFlagsetParseFailed))
+		})
+	}
+}
+
+func Test_HelpRequested(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard",
+			input:    "PING",
+			expected: "help requested PING",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "help requested ",
+		},
+		{
+			name:     "lowercase",
+			input:    "ping",
+			expected: "help requested ping",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := HelpRequested(test.input)
+			assert.Equal(t, test.expected, actual.Error())
+			assert.True(t, errors.Is(actual, errHelpRequested))
+		})
+	}
+}
+
+func Test_IsHelpRequested(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "error",
+			err:      fmt.Errorf("help"),
+			expected: false,
+		},
+		{
+			name:     "help",
+			err:      HelpRequested("me"),
+			expected: true,
+		},
+		{
+			name:     "wrongly wrapped",
+			err:      fmt.Errorf("%v", HelpRequested("me")),
+			expected: false,
+		},
+		{
+			name:     "wrapped",
+			err:      fmt.Errorf("%w", HelpRequested("me")),
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := IsHelpRequested(test.err)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -106,6 +106,38 @@ func Test_FlagsetParseFailed(t *testing.T) {
 		})
 	}
 }
+func Test_FlagsetSetFailed(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard",
+			input:    "PING",
+			expected: "flagset set failed PING",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "flagset set failed ",
+		},
+		{
+			name:     "lowercase",
+			input:    "ping",
+			expected: "flagset set failed ping",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := FlagsetSetFailed(test.input)
+			assert.Equal(t, test.expected, actual.Error())
+			assert.True(t, errors.Is(actual, errFlagsetSetFailed))
+		})
+	}
+}
 
 func Test_HelpRequested(t *testing.T) {
 

--- a/examples/cli/go.mod
+++ b/examples/cli/go.mod
@@ -1,0 +1,5 @@
+module examples/cli
+
+go 1.17
+
+require github.com/evilmonkeyinc/golang-cli v0.7.0

--- a/examples/cli/go.sum
+++ b/examples/cli/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/evilmonkeyinc/golang-cli v0.7.0 h1:5lOuqjYNg2ba22KboKYe5E87EvI3z521y816oTg3ksY=
+github.com/evilmonkeyinc/golang-cli v0.7.0/go.mod h1:uWwhAgOkV9Ua1et3E8WEFEiFnErxsHfr4s6cFzNDItY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/shell/go.mod
+++ b/examples/shell/go.mod
@@ -1,0 +1,5 @@
+module examples/shell
+
+go 1.17
+
+require github.com/evilmonkeyinc/golang-cli v0.7.0

--- a/examples/shell/go.sum
+++ b/examples/shell/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/evilmonkeyinc/golang-cli v0.7.0 h1:5lOuqjYNg2ba22KboKYe5E87EvI3z521y816oTg3ksY=
+github.com/evilmonkeyinc/golang-cli v0.7.0/go.mod h1:uWwhAgOkV9Ua1et3E8WEFEiFnErxsHfr4s6cFzNDItY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/flags/flagset.go
+++ b/flags/flagset.go
@@ -20,7 +20,7 @@ type FlagSet interface {
 
 	// Parse parses flag definitions from the argument list, which should not include the command name, and return remaining, non-flag, arguments.
 	// Must be called after all flags in the FlagSet are defined and before flags are accessed by the program.
-	// The return value will be ErrHelp if -help was set but not defined.
+	// The return value will be an HelpRequested error if -help was set but not defined.
 	Parse(args []string) ([]string, error)
 	// Parsed returns true if Parse has been called.
 	Parsed() bool
@@ -148,7 +148,11 @@ func (flagSet *DefaultFlagSet) Parsed() bool {
 // Set sets the value of the named flag.
 func (flagSet *DefaultFlagSet) Set(name, value string) error {
 	flagSet.setup()
-	return flagSet.set.Set(name, value)
+	if err := flagSet.set.Set(name, value); err != nil {
+		return errors.FlagsetSetFailed(err.Error())
+	}
+
+	return nil
 }
 
 // Get returns the value of the named flag.

--- a/flags/flagset.go
+++ b/flags/flagset.go
@@ -2,14 +2,12 @@ package flags
 
 import (
 	"bytes"
+	goerrors "errors"
 	"flag"
 	"strings"
 	"time"
-)
 
-var (
-	// ErrHelp is the error returned if the -help or -h flag is invoked but no such flag is defined.
-	ErrHelp error = flag.ErrHelp
+	"github.com/evilmonkeyinc/golang-cli/errors"
 )
 
 // A FlagSet represents a set of defined flags
@@ -132,8 +130,13 @@ func (flagSet *DefaultFlagSet) SubFlagSet(name string) FlagSet {
 // The return value will be ErrHelp if -help was set but not defined.
 func (flagSet *DefaultFlagSet) Parse(args []string) ([]string, error) {
 	flagSet.setup()
-	result := flagSet.set.Parse(args)
-	return flagSet.set.Args(), result
+	if err := flagSet.set.Parse(args); err != nil {
+		if goerrors.Is(err, flag.ErrHelp) {
+			return flagSet.set.Args(), errors.HelpRequested("flags")
+		}
+		return flagSet.set.Args(), errors.FlagsetParseFailed(err.Error())
+	}
+	return flagSet.set.Args(), nil
 }
 
 // Parsed returns true if Parse has been called.

--- a/flags/flagset_test.go
+++ b/flags/flagset_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evilmonkeyinc/golang-cli/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -240,13 +241,19 @@ func Test_DefaultFlagSet_ParseArgs(t *testing.T) {
 			name:          "short help",
 			input:         []string{"-h"},
 			expected:      []string{},
-			expectedError: ErrHelp,
+			expectedError: errors.HelpRequested("flags"),
 		},
 		{
 			name:          "long help",
 			input:         []string{"--help"},
 			expected:      []string{},
-			expectedError: ErrHelp,
+			expectedError: errors.HelpRequested("flags"),
+		},
+		{
+			name:          "unknown flag",
+			input:         []string{"--unknown"},
+			expected:      []string{},
+			expectedError: errors.FlagsetParseFailed("flag provided but not defined: -unknown"),
 		},
 	}
 

--- a/flags/flagset_test.go
+++ b/flags/flagset_test.go
@@ -303,7 +303,7 @@ func Test_DefaultFlagSet_Set(t *testing.T) {
 				fn:    func(fd FlagDefiner) {},
 			},
 			expected: expected{
-				err:   fmt.Errorf("no such flag -missing"),
+				err:   errors.FlagsetSetFailed("no such flag -missing"),
 				value: nil,
 			},
 		},
@@ -331,7 +331,7 @@ func Test_DefaultFlagSet_Set(t *testing.T) {
 				},
 			},
 			expected: expected{
-				err:   fmt.Errorf("parse error"),
+				err:   errors.FlagsetSetFailed("parse error"),
 				value: false,
 			},
 		},
@@ -357,7 +357,7 @@ func Test_DefaultFlagSet_Set(t *testing.T) {
 			test.input.fn(flagSet)
 
 			actualErr := flagSet.Set(test.input.name, test.input.value)
-			assert.Equal(t, test.expected.err, actualErr)
+			assert.EqualValues(t, test.expected.err, actualErr)
 
 			actualVal := flagSet.Get(test.input.name)
 			assert.Equal(t, test.expected.value, actualVal)

--- a/shell/options.go
+++ b/shell/options.go
@@ -130,3 +130,27 @@ func (option *flagSetOption) Apply(shell *Shell) error {
 	shell.flagSet = option.flagSet
 	return nil
 }
+
+// OptionHelpHandler shell option allows the user to set the HelpHandler used by the shell.
+//
+// The HelpHandler will be executed whenever a handler returns the HelpRequested error.
+func OptionHelpHandler(handler Handler) Option {
+	if handler == nil {
+		panic(errors.OptionIsInvalid("HelpHandler"))
+	}
+	return &helpHandlerOption{
+		handler: handler,
+	}
+}
+
+type helpHandlerOption struct {
+	handler Handler
+}
+
+func (option *helpHandlerOption) Apply(shell *Shell) error {
+	if shell.helpHandler != nil {
+		return errors.OptionIsSet("HelpHandler")
+	}
+	shell.helpHandler = option.handler
+	return nil
+}

--- a/shell/request_test.go
+++ b/shell/request_test.go
@@ -110,7 +110,6 @@ func Test_Request_FlagValues(t *testing.T) {
 }
 
 func Test_Request_UpdateRequest(t *testing.T) {
-	// TODO : need to support args being changes and flagsets
 	type input struct {
 		selectedRoute string
 	}

--- a/shell/router.go
+++ b/shell/router.go
@@ -108,7 +108,9 @@ func (rtr *StandardRouter) Execute(writer ResponseWriter, request *Request) erro
 		}
 		var parseErr error = nil
 		if args, parseErr = flagSet.Parse(args[1:]); parseErr != nil {
-			// TODO : check for ErrHelp
+			if errors.IsHelpRequested(parseErr) {
+				return parseErr
+			}
 			fmt.Fprintln(writer.ErrorWriter(), parseErr.Error())
 		}
 		request = request.UpdateRequest(currentRoute, args, flagSet, rtr)

--- a/shell/router_test.go
+++ b/shell/router_test.go
@@ -603,6 +603,15 @@ func Test_Router_Flags(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "-help",
+			input: input{
+				args: []string{"one", "-h"},
+			},
+			expected: expected{
+				err: errors.HelpRequested("flags"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/shell/router_test.go
+++ b/shell/router_test.go
@@ -478,7 +478,7 @@ func Test_Router_Flags(t *testing.T) {
 			expected: expected{
 				err:        nil,
 				parsed:     map[string]interface{}{},
-				parseError: "flag provided but not defined: -two\n",
+				parseError: "flagset parse failed flag provided but not defined: -two\n",
 			},
 		},
 		{

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/evilmonkeyinc/golang-cli/errors"
 	"github.com/evilmonkeyinc/golang-cli/flags"
 	"github.com/stretchr/testify/assert"
 )
@@ -765,4 +766,34 @@ func Test_Shell_Start(t *testing.T) {
 
 		})
 	}
+}
+
+func Test_Shell_HelpFallback(t *testing.T) {
+
+	shell := &Shell{}
+	shell.Flags(flags.FlagHandlerFunction(func(fd flags.FlagDefiner) {
+		fd.Bool("toUpper", false, "")
+	}))
+	shell.HandleFunction("help", func(ResponseWriter, *Request) error {
+		return errors.HelpRequested("")
+	})
+
+	shell.helpHandler = HandlerFunction(func(ResponseWriter, *Request) error {
+		return fmt.Errorf("help handler was called")
+	})
+
+	t.Run("short help flag", func(t *testing.T) {
+		actual := shell.execute(context.Background(), []string{"-h", "ping"})
+		assert.EqualError(t, actual, "help handler was called")
+	})
+
+	t.Run("long help flag", func(t *testing.T) {
+		actual := shell.execute(context.Background(), []string{"-help", "ping"})
+		assert.EqualError(t, actual, "help handler was called")
+	})
+
+	t.Run("handler returning help", func(t *testing.T) {
+		actual := shell.execute(context.Background(), []string{"help", "ping"})
+		assert.EqualError(t, actual, "help handler was called")
+	})
 }

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -119,7 +119,7 @@ func Test_Shell(t *testing.T) {
 		assert.NotNil(t, testRouter.flags)
 
 		actual.execute(context.Background(), []string{"-found", "-missing"})
-		assert.Equal(t, "flag provided but not defined: -missing\n", errWriter.String())
+		assert.Equal(t, "flagset parse failed flag provided but not defined: -missing\n", errWriter.String())
 	})
 
 }


### PR DESCRIPTION
Add functionality, and option, to set Handler for shell to act as a help function

the help handler is executed when a router/handler returns a HelpRequested error

The default FlagSet has been updated so when it receives a flag.ErrHelp it will instead return a HelpRequested error